### PR TITLE
搜索用的商品列表参数顺序调整

### DIFF
--- a/src/Goods/Goods.php
+++ b/src/Goods/Goods.php
@@ -25,7 +25,7 @@ class Goods extends AbstractAPI
      *
      * @return \Mayunfeng\Supports\Collection
      */
-    public function goodsList(int $page = 1, int $size = 10, string $search = '', int $proId = 0, array $goodsIds = [])
+    public function goodsList(array $goodsIds = [],int $proId = 0,string $search = '',int $page = 1, int $size = 10)
     {
         return $this->parseJSON(static::POST, [
             self::GOODS_LIST,


### PR DESCRIPTION
调整了参数顺序

public function goodsList(array $goodsIds = [],int $proId = 0,string $search = '',int $page = 1, int $size = 10)
按商品数组集合 、 商品码 、搜索内容、页码、页最大值 传入参数即可使用